### PR TITLE
Rename Airbnb terms to Beach

### DIFF
--- a/samples/beach-party-app/README.md
+++ b/samples/beach-party-app/README.md
@@ -9,7 +9,7 @@ This document describes a web application demonstrating the integration of Googl
 
 ### Architecture
 
-The application utilizes a multi-agent architecture where a host agent delegates tasks to remote agents (Airbnb and Weather) based on the user's query. These agents then interact with corresponding MCP servers.
+The application utilizes a multi-agent architecture where a host agent delegates tasks to remote agents (Beach and Weather) based on the user's query. These agents then interact with corresponding MCP servers.
 
 ![architecture](assets/A2A_multi_agent.png)
 
@@ -23,7 +23,7 @@ The application utilizes a multi-agent architecture where a host agent delegates
 
 Before running the application locally, ensure you have the following installed:
 
-1. **Node.js:** Required to run the Airbnb MCP server (if testing its functionality locally).
+1. **Node.js:** Required to run the Beach MCP server (if testing its functionality locally).
 2. **uv:** The Python package management tool used in this project. Follow the installation guide: [https://docs.astral.sh/uv/getting-started/installation/](https://docs.astral.sh/uv/getting-started/installation/)
 3. **python 3.13** Python 3.13 is required to run a2a-sdk 
 4. **set up .env** 
@@ -46,7 +46,7 @@ WEA_AGENT_URL=http://localhost:10001
 
 
 
-## 1. Run Airbnb server
+## 1. Run Beach server
 
 Run Remote server
 

--- a/samples/beach-party-app/beach_agent/README.md
+++ b/samples/beach-party-app/beach_agent/README.md
@@ -1,12 +1,12 @@
-# Airbnb Agent - LangGraphベースのAIエージェント
+# Beach Agent - LangGraphベースのAIエージェント
 
 ## 概要
 
-AirbnbAgentは、Airbnb宿泊施設の検索と関連する質問に特化したAIエージェントです。LangGraphとGoogle GenerativeAI（Gemini）を使用して構築されており、MCPツールを活用してAirbnb物件の検索機能を提供します。
+BeachAgentは、Beach宿泊施設の検索と関連する質問に特化したAIエージェントです。LangGraphとGoogle GenerativeAI（Gemini）を使用して構築されており、MCPツールを活用してBeach物件の検索機能を提供します。
 
 ## 主な機能
 
-- **Airbnb物件検索**: MCPツールを使用した宿泊施設の検索
+- **Beach物件検索**: MCPツールを使用した宿泊施設の検索
 - **対話型応答**: ユーザーとの自然な会話形式での情報提供
 - **ストリーミング対応**: リアルタイムでの応答生成
 - **セッション管理**: メモリ機能による会話履歴の保持
@@ -16,7 +16,7 @@ AirbnbAgentは、Airbnb宿泊施設の検索と関連する質問に特化した
 
 ### コアコンポーネント
 
-#### 1. `AirbnbAgent`クラス
+#### 1. `BeachAgent`クラス
 - **役割**: メインのエージェントクラス
 - **機能**: 
   - Google Gemini 2.5 Flash PreviewモデルとのインターフェースMCP
@@ -40,7 +40,7 @@ class ResponseFormat(BaseModel):
 #### エージェントの動作フロー
 1. **初期化**: MCPツールとGeminiモデルの設定
 2. **クエリ受信**: ユーザーからの検索リクエスト
-3. **ツール実行**: MCPツールを使用したAirbnb API呼び出し
+3. **ツール実行**: MCPツールを使用したBeach API呼び出し
 4. **応答生成**: 構造化された形式での結果返却
 
 #### メモリ管理
@@ -55,7 +55,7 @@ class ResponseFormat(BaseModel):
 **非同期でクエリを実行し、完全な応答を返す**
 
 **パラメータ:**
-- `query`: 検索クエリ（例：「東京のAirbnb物件を探して」）
+- `query`: 検索クエリ（例：「東京のBeach物件を探して」）
 - `sessionId`: セッション識別子
 
 **戻り値:**
@@ -110,13 +110,13 @@ class ResponseFormat(BaseModel):
 
 #### 基本的な使用方法
 ```python
-from airbnb_agent.agent import AirbnbAgent
+from airbnb_agent.agent import BeachAgent
 
 # MCPツールの設定（実際の実装に応じて）
-mcp_tools = [...]  # Airbnb検索ツール
+mcp_tools = [...]  # Beach検索ツール
 
 # エージェント初期化
-agent = AirbnbAgent(mcp_tools=mcp_tools)
+agent = BeachAgent(mcp_tools=mcp_tools)
 
 # 同期呼び出し
 response = await agent.ainvoke(
@@ -130,7 +130,7 @@ print(response["content"])
 #### ストリーミング使用例
 ```python
 async for chunk in agent.stream(
-    query="渋谷近くのAirbnb物件を教えて",
+    query="渋谷近くのBeach物件を教えて",
     sessionId="user_session_123"
 ):
     print(chunk["content"])
@@ -140,7 +140,7 @@ async for chunk in agent.stream(
 
 ### システム指示（SYSTEM_INSTRUCTION）
 エージェントは以下の指示で動作します：
-- Airbnb宿泊施設専門のアシスタント
+- Beach宿泊施設専門のアシスタント
 - 提供されたツールのみを使用
 - 物件情報や価格の捏造禁止
 - Markdown形式での応答
@@ -163,7 +163,7 @@ async for chunk in agent.stream(
 {
     "is_task_complete": True,
     "require_user_input": False,
-    "content": "申し訳ございませんが、現在Airbnb検索ツールが利用できません。後ほど再試行してください。"
+    "content": "申し訳ございませんが、現在Beach検索ツールが利用できません。後ほど再試行してください。"
 }
 ```
 

--- a/samples/beach-party-app/beach_agent/__main__.py
+++ b/samples/beach-party-app/beach_agent/__main__.py
@@ -7,8 +7,8 @@ from contextlib import asynccontextmanager
 import click
 import uvicorn
 
-from agent import BeachAgent  # Renamed from AirbnbAgent
-from agent_executor import BeachAgentExecutor  # Renamed from AirbnbAgentExecutor
+from agent import BeachAgent  # Renamed from BeachAgent
+from agent_executor import BeachAgentExecutor  # Renamed from BeachAgentExecutor
 from dotenv import load_dotenv
 
 from a2a.server.apps import A2AStarletteApplication

--- a/samples/beach-party-app/beach_agent/agent.py
+++ b/samples/beach-party-app/beach_agent/agent.py
@@ -28,7 +28,7 @@ class ResponseFormat(BaseModel):
     message: str
 
 
-class BeachAgent:  # Renamed from AirbnbAgent
+class BeachAgent:  # Renamed from BeachAgent
     """Beach Search Agent Example."""  # Updated docstring
 
     SYSTEM_INSTRUCTION = """You are a specialized assistant for beach information. Your primary function is to utilize the provided tools to search for beaches and answer related questions. You must rely exclusively on these tools for information; do not invent beach details or conditions. Ensure that your Markdown-formatted response includes all relevant tool output, with particular emphasis on providing accurate information.""" # Updated instruction

--- a/samples/beach-party-app/beach_agent/agent_executor.py
+++ b/samples/beach-party-app/beach_agent/agent_executor.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 import logging
-from agent import AirbnbAgent
+from agent import BeachAgent
 
 from typing_extensions import override
 
@@ -19,21 +19,21 @@ from uuid import uuid4
 logger = logging.getLogger(__name__)
 
 
-class AirbnbAgentExecutor(AgentExecutor):
-    """AirbnbAgentExecutor that uses an agent with preloaded tools."""
+class BeachAgentExecutor(AgentExecutor):
+    """BeachAgentExecutor that uses an agent with preloaded tools."""
 
     def __init__(self, mcp_tools: List[Any]):
         """
-        Initializes the AirbnbAgentExecutor.
+        Initializes the BeachAgentExecutor.
 
         Args:
-            mcp_tools: A list of preloaded MCP tools for the AirbnbAgent.
+            mcp_tools: A list of preloaded MCP tools for the BeachAgent.
         """
         super().__init__()
         logger.info(
-            f"Initializing AirbnbAgentExecutor with {len(mcp_tools) if mcp_tools else 'no'} MCP tools."
+            f"Initializing BeachAgentExecutor with {len(mcp_tools) if mcp_tools else 'no'} MCP tools."
         )
-        self.agent = AirbnbAgent(mcp_tools=mcp_tools)
+        self.agent = BeachAgent(mcp_tools=mcp_tools)
 
     @override
     async def execute(


### PR DESCRIPTION
## Summary
- update `BeachAgentExecutor` to import `BeachAgent`
- switch docs and comments in `beach-party-app` from Airbnb to Beach

## Testing
- `nox -s format` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6843055ddc3c832f89c315e2dc300394