### PR TITLE
Rename AIR_AGENT_URL to BEACH_AGENT_URL

### DIFF
--- a/samples/a2a-adk-app/README.md
+++ b/samples/a2a-adk-app/README.md
@@ -40,7 +40,7 @@ GOOGLE_API_KEY="your_api_key_here"
 GOOGLE_GENAI_USE_VERTEXAI=TRUE
 GOOGLE_CLOUD_PROJECT="your project"
 GOOGLE_CLOUD_LOCATION=us-central1
-AIR_AGENT_URL=http://localhost:10002
+BEACH_AGENT_URL=http://localhost:10002
 WEA_AGENT_URL=http://localhost:10001
 ```
 

--- a/samples/a2a-adk-app/host_agent/adk_agent/.env.example
+++ b/samples/a2a-adk-app/host_agent/adk_agent/.env.example
@@ -16,5 +16,5 @@ GOOGLE_GENAI_USE_VERTEXAI=TRUE
 GOOGLE_CLOUD_PROJECT="your project id"
 GOOGLE_API_KEY="your key"
 GOOGLE_CLOUD_LOCATION=us-central1
-AIR_AGENT_URL=http://localhost:10002
+BEACH_AGENT_URL=http://localhost:10002
 WEA_AGENT_URL=http://localhost:10001

--- a/samples/a2a-adk-app/host_agent/adk_agent/README.md
+++ b/samples/a2a-adk-app/host_agent/adk_agent/README.md
@@ -10,7 +10,7 @@ This example shows how to create an A2A Server that uses an ADK-based Agent.
    GOOGLE_GENAI_USE_VERTEXAI=TRUE
    GOOGLE_CLOUD_PROJECT="your project id"
    GOOGLE_CLOUD_LOCATION=us-central1
-   AIR_AGENT_URL=http://localhost:10002
+   BEACH_AGENT_URL=http://localhost:10002
    WEA_AGENT_URL=http://localhost:10001
    ```
 

--- a/samples/a2a-adk-app/host_agent/adk_agent/agent.py
+++ b/samples/a2a-adk-app/host_agent/adk_agent/agent.py
@@ -281,7 +281,7 @@ def _get_initialized_routing_agent_sync():
     async def _async_main():
         routing_agent_instance = await RoutingAgent.create(
             remote_agent_addresses=[
-                os.getenv("AIR_AGENT_URL", "http://localhost:10002"),
+                os.getenv("BEACH_AGENT_URL", "http://localhost:10002"),
                 os.getenv("WEA_AGENT_URL", "http://localhost:10001"),
             ]
         )

--- a/samples/beach-party-app/README.md
+++ b/samples/beach-party-app/README.md
@@ -40,7 +40,7 @@ GOOGLE_API_KEY="your_api_key_here"
 GOOGLE_GENAI_USE_VERTEXAI=TRUE
 GOOGLE_CLOUD_PROJECT="your project"
 GOOGLE_CLOUD_LOCATION=us-central1
-AIR_AGENT_URL=http://localhost:10002
+BEACH_AGENT_URL=http://localhost:10002
 WEA_AGENT_URL=http://localhost:10001
 ```
 

--- a/samples/beach-party-app/host_agent/adk_agent/.env.example
+++ b/samples/beach-party-app/host_agent/adk_agent/.env.example
@@ -16,5 +16,5 @@ GOOGLE_GENAI_USE_VERTEXAI=TRUE
 GOOGLE_CLOUD_PROJECT="your project id"
 GOOGLE_API_KEY="your key"
 GOOGLE_CLOUD_LOCATION=us-central1
-AIR_AGENT_URL=http://localhost:10002
+BEACH_AGENT_URL=http://localhost:10002
 WEA_AGENT_URL=http://localhost:10001

--- a/samples/beach-party-app/host_agent/adk_agent/README.md
+++ b/samples/beach-party-app/host_agent/adk_agent/README.md
@@ -10,7 +10,7 @@ This example shows how to create an A2A Server that uses an ADK-based Agent.
    GOOGLE_GENAI_USE_VERTEXAI=TRUE
    GOOGLE_CLOUD_PROJECT="your project id"
    GOOGLE_CLOUD_LOCATION=us-central1
-   AIR_AGENT_URL=http://localhost:10002
+   BEACH_AGENT_URL=http://localhost:10002
    WEA_AGENT_URL=http://localhost:10001
    ```
 

--- a/samples/beach-party-app/host_agent/adk_agent/agent.py
+++ b/samples/beach-party-app/host_agent/adk_agent/agent.py
@@ -281,7 +281,7 @@ def _get_initialized_routing_agent_sync():
     async def _async_main():
         routing_agent_instance = await RoutingAgent.create(
             remote_agent_addresses=[
-                os.getenv("AIR_AGENT_URL", "http://localhost:10002"),
+                os.getenv("BEACH_AGENT_URL", "http://localhost:10002"),
                 os.getenv("WEA_AGENT_URL", "http://localhost:10001"),
             ]
         )


### PR DESCRIPTION
## Summary
- replace environment variable `AIR_AGENT_URL` with `BEACH_AGENT_URL`
- update docs and `.env.example` files to use `BEACH_AGENT_URL`
- adjust host agent code to read the new environment variable

## Testing
- `nox -s format`

------
https://chatgpt.com/codex/tasks/task_b_6843055f7b58832fb41b23a051a00459