### PR TITLE
Implement CLI for beach-party sample

### DIFF
--- a/samples/beach-party-app/README.md
+++ b/samples/beach-party-app/README.md
@@ -44,6 +44,22 @@ AIR_AGENT_URL=http://localhost:10002
 WEA_AGENT_URL=http://localhost:10001
 ```
 
+## Quick Start
+
+Use the `main.py` CLI to launch the agents.
+
+Start only the host agent:
+
+```bash
+uv run main.py host
+```
+
+Start all agents (weather, beach and host) at once:
+
+```bash
+uv run main.py all
+```
+
 
 
 ## 1. Run Airbnb server

--- a/samples/beach-party-app/main.py
+++ b/samples/beach-party-app/main.py
@@ -1,6 +1,50 @@
-def main():
-    print("Hello from a2a-mcp-app!")
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+APP_DIR = Path(__file__).resolve().parent
+
+
+def _spawn(cmd: list[str]) -> subprocess.Popen:
+    """Start a subprocess in the sample directory."""
+    return subprocess.Popen(cmd, cwd=APP_DIR)
+
+
+@click.group(help="Utilities for running the beach party sample")
+def cli() -> None:
+    """Command group for agent management."""
+    pass
+
+
+@cli.command(help="Start only the host agent")
+def host() -> None:
+    subprocess.run([sys.executable, "host_agent/app.py"], cwd=APP_DIR, check=True)
+
+
+@cli.command(help="Start the weather agent")
+def weather() -> None:
+    subprocess.run([sys.executable, "-m", "weather_agent"], cwd=APP_DIR, check=True)
+
+
+@cli.command(help="Start the beach agent")
+def beach() -> None:
+    subprocess.run([sys.executable, "-m", "beach_agent"], cwd=APP_DIR, check=True)
+
+
+@cli.command(name="all", help="Start weather, beach and host agents")
+def start_all() -> None:
+    processes = [
+        _spawn([sys.executable, "-m", "weather_agent"]),
+        _spawn([sys.executable, "-m", "beach_agent"]),
+    ]
+    try:
+        subprocess.run([sys.executable, "host_agent/app.py"], cwd=APP_DIR, check=True)
+    finally:
+        for proc in processes:
+            proc.terminate()
 
 
 if __name__ == "__main__":
-    main()
+    cli()


### PR DESCRIPTION
## Summary
- add a click-based CLI in `main.py` to start the beach-party agents
- document the new script in the sample README

## Testing
- `uv run pytest -v` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_b_68430560dc6c832fa487b225950af39f