### PR TITLE
Fix imports for beach-party sample

### DIFF
--- a/samples/beach-party-app/beach_agent/__main__.py
+++ b/samples/beach-party-app/beach_agent/__main__.py
@@ -7,8 +7,8 @@ from contextlib import asynccontextmanager
 import click
 import uvicorn
 
-from agent import BeachAgent  # Renamed from BeachAgent
-from agent_executor import BeachAgentExecutor  # Renamed from BeachAgentExecutor
+from .agent import BeachAgent  # Renamed from BeachAgent
+from .agent_executor import BeachAgentExecutor  # Renamed from BeachAgentExecutor
 from dotenv import load_dotenv
 
 from a2a.server.apps import A2AStarletteApplication

--- a/samples/beach-party-app/beach_agent/agent_executor.py
+++ b/samples/beach-party-app/beach_agent/agent_executor.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 import logging
-from agent import BeachAgent
+from .agent import BeachAgent
 
 from typing_extensions import override
 

--- a/samples/beach-party-app/weather_agent/__main__.py
+++ b/samples/beach-party-app/weather_agent/__main__.py
@@ -4,8 +4,8 @@ import os
 import click
 import uvicorn
 
-from adk_agent import create_agent
-from adk_agent_executor import ADKAgentExecutor
+from .adk_agent import create_agent
+from .adk_agent_executor import ADKAgentExecutor
 from dotenv import load_dotenv
 from google.adk.artifacts import InMemoryArtifactService
 from google.adk.memory.in_memory_memory_service import InMemoryMemoryService


### PR DESCRIPTION
## Summary
- fix module imports in `beach_agent` and `weather_agent` to use relative paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a')*
- `python samples/beach-party-app/main.py beach` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_b_68431607c1bc832fab013139ef25f9f8